### PR TITLE
Set margin sizes on buttons to prevent '...' in button label

### DIFF
--- a/src/main/ui/cli/ItemView.java
+++ b/src/main/ui/cli/ItemView.java
@@ -92,6 +92,7 @@ public class ItemView extends JPanel {
         JButton button = new JButton("X");
         int size = (int) button.getMaximumSize().getHeight();
         button.setMaximumSize(new Dimension(size, size));
+        button.setMargin(new Insets(0, 0, 0, 0));
         button.addActionListener(i -> {
             Container parent = this.getParent();
             parent.remove(this);
@@ -115,6 +116,7 @@ public class ItemView extends JPanel {
         button = new JButton("►");
         size = (int) button.getMaximumSize().getHeight();
         button.setMaximumSize(new Dimension(size, size));
+        button.setMargin(new Insets(0, 0, 0, 0));
         button.addActionListener(i -> {
             Container parent = this.getParent();
             if (parent instanceof GUInterface) {

--- a/src/main/ui/cli/SearchBar.java
+++ b/src/main/ui/cli/SearchBar.java
@@ -7,6 +7,7 @@ import ui.GUInterface;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +24,8 @@ public class SearchBar extends JPanel {
     private final ScopedSearch searchService;
     private final ArrayList<Value> results;
 
+    private boolean submitted;
+
     /*
      * REQUIRES: searchService is not null
      * MODIFIES: this
@@ -31,9 +34,15 @@ public class SearchBar extends JPanel {
     public SearchBar(ScopedSearch searchService) {
         this.searchService = searchService;
         results = new ArrayList<>(50);
+        submitted = true;
 
         JTextField textField = new JTextField("Search");
-        textField.addActionListener((i) -> parse(Collections.singletonList(textField.getText())));
+        textField.addActionListener((i) -> {
+            submitted = true;
+            parse(Collections.singletonList(textField.getText()));
+        });
+        textField.addMouseListener(new SearchMouseAdapter(this));
+        textField.addKeyListener(new SearchKeyAdapter(this));
         this.setLayout(new GridLayout());
         add(textField);
         textField.setBackground(GUInterface.brightGray);
@@ -107,5 +116,33 @@ public class SearchBar extends JPanel {
      */
     public Function<List<String>, Boolean> getParser() {
         return this::parse;
+    }
+
+    class SearchMouseAdapter extends MouseAdapter {
+        SearchBar bar;
+
+        public SearchMouseAdapter(SearchBar bar) {
+            this.bar = bar;
+        }
+
+        public void mousePressed(MouseEvent e) {
+            if (bar.submitted) {
+                JTextField field = (JTextField) e.getSource();
+                field.selectAll();
+            }
+        }
+    }
+
+    class SearchKeyAdapter extends KeyAdapter {
+        SearchBar bar;
+
+        public SearchKeyAdapter(SearchBar bar) {
+            this.bar = bar;
+        }
+
+        @Override
+        public void keyPressed(KeyEvent keyEvent) {
+            bar.submitted = false;
+        }
     }
 }


### PR DESCRIPTION
On Linux, when viewing a button, the close and right-arrow buttons do not display properly, and instead display as '...'.

This patch fixes the issue.

Before:
![Screenshot from 2020-08-15 21-53-14](https://user-images.githubusercontent.com/7741326/90326815-bde52200-df41-11ea-8e34-c0a30362142f.png)

After:
![Screenshot from 2020-08-15 21-53-53](https://user-images.githubusercontent.com/7741326/90326826-d48b7900-df41-11ea-9f7a-772fb9cac8be.png)
